### PR TITLE
fix: use UTC for date bucketing (fixes #10)

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,8 +1,8 @@
 /**
- * Convert a timestamp to the start-of-day timestamp in local timezone.
- * Used for bucketing data points by calendar day.
+ * Convert a timestamp to the start-of-day UTC timestamp.
+ * Used for bucketing data points by calendar day (consistent across server/client/timezones).
  */
 export const toDateKey = (ts: number): number => {
   const d = new Date(ts);
-  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
 };


### PR DESCRIPTION
## Summary
Timezone-dependent date bucketing caused server (UTC) and client (local) to use different daily boundaries. `toDateKey` in `src/shared/utils.ts` now uses `Date.UTC` and `getUTC*` so day boundaries are consistent.

## Changes
- `toDateKey(ts)` returns start-of-day in UTC instead of local time
- Shared by Dashboard and ActivityLog; single fix covers both

Made with [Cursor](https://cursor.com)